### PR TITLE
Use Bcrypt encryption instead of md5 for login

### DIFF
--- a/core/admin/createconfig.php
+++ b/core/admin/createconfig.php
@@ -68,7 +68,7 @@ if(isUserLogged()) { //if logged
 
 	$username = "'.$username.'";
 
-	$userpassword = "'.$userpassword.'";
+	$userpassword = \''.$userpassword.'\';
 
 	$max_upload_form_size = "'.$max_upload_form_size.'"; //e.g.: "30000000" (about 30MB)
 

--- a/core/admin/login.php
+++ b/core/admin/login.php
@@ -46,7 +46,7 @@ if(isset($_GET['action']) AND $_GET['action'] == "logout" ){
 
 // check if user is already logged in 
 
-if(isset($_SESSION["user_session"]) AND $_SESSION["user_session"]==$username AND md5($_SESSION["password_session"])==$userpassword){ //if so, keep displaying the page
+if(isset($_SESSION["user_session"]) AND $_SESSION["user_session"]==$username AND password_verify($_SESSION["password_session"],$userpassword)){ //if so, keep displaying the page
 
 
 if (!useNewThemeEngine($theme_path)) { //if is not new theme engine
@@ -62,7 +62,7 @@ if (!useNewThemeEngine($theme_path)) { //if is not new theme engine
 	
 }else{
 
-	if(isset($_POST["user"]) AND $_POST["user"]==$username AND isset($_POST["password"]) AND md5($_POST["password"])==$userpassword){ //if user and pwd are valid
+	if(isset($_POST["user"]) AND $_POST["user"]==$username AND isset($_POST["password"]) AND password_verify($_POST["password"],$userpassword)){ //if user and pwd are valid
 
 	if (!useNewThemeEngine($theme_path)) { //if is not new theme engine
 		$PG_mainbody .= '<div class="episode">

--- a/core/functions.php
+++ b/core/functions.php
@@ -1547,10 +1547,10 @@ function isUserLogged () {
 	//// Security code (Register Globals ON)
 	if (isset($_REQUEST['GLOBALS'])) { exit; } 
 	
-	//read user and md5 pwd from config.php
+	//read user and bcrypt pwd from config.php
 	if (file_exists("config.php")) include("config.php"); 
-	//compare sessions to stored user and md5 pwd
-	if(isset($_SESSION["user_session"]) AND $_SESSION["user_session"]==$username AND md5($_SESSION["password_session"])==$userpassword) { return TRUE; }
+	//compare sessions to stored user and bcrypt pwd
+	if(isset($_SESSION["user_session"]) AND $_SESSION["user_session"]==$username AND password_verify($_SESSION["password_session"],$userpassword)) { return TRUE; }
 	else { return FALSE; }
 }
 

--- a/setup/firstcreateconfig.php
+++ b/setup/firstcreateconfig.php
@@ -48,7 +48,7 @@ $theme_path = "themes/default_modern/";
 
 $username = "'.$user.'";
 
-$userpassword = "'.md5($pwd).'";
+$userpassword = \''.password_hash($pwd,PASSWORD_BCRYPT).'\';
 
 $max_upload_form_size = "104857600"; //e.g.: "30000000" (about 30MB)
 


### PR DESCRIPTION
I switched the deprecated md5 hashes to the default php bcrypt hash
function.
