### PR TITLE
issue #167: improve getEpisodes() performance

### DIFF
--- a/PodcastGenerator/core/episodes.php
+++ b/PodcastGenerator/core/episodes.php
@@ -17,35 +17,46 @@ function getEpisodes($category = null)
     }
     $supported_extensions = $realsupported_extensions;
     unset($realsupported_extensions);
-    // Get episodes names
-    $episodes = array();
+
+    // Get episodes names and pubDates (which are the file
+    // modification times).  We'll ignore files with future
+    // timestamps.
+    $now_time = time();
+    $episodes_mtimes = array();
     if ($handle = opendir($_config['upload_dir'])) {
         while (false !== ($entry = readdir($handle))) {
-            // Check if the file is a 'real' file and if has a linked XML file
-            if (in_array(pathinfo($_config['upload_dir'] . $entry, PATHINFO_EXTENSION), $supported_extensions) && file_exists($_config['upload_dir'] . pathinfo($_config['upload_dir'] . $entry, PATHINFO_FILENAME) . '.xml')) {
-                array_push($episodes, $entry);
+            // If the file is a 'real' file, has a linked XML file,
+            // and isn't from the future, add its name and
+            // modification time to our array.
+            $this_entry = $_config['upload_dir'] . $entry;
+            $this_mtime = filemtime($this_entry);
+            if (in_array(pathinfo($this_entry, PATHINFO_EXTENSION), $supported_extensions)
+                && file_exists($_config['upload_dir'] . pathinfo($this_entry, PATHINFO_FILENAME) . '.xml')
+                && $this_mtime <= $now_time) {
+                array_push($episodes_mtimes, [$entry, $this_mtime]);
             }
         }
     }
-    // Bubble sort files according to their pubDate
-    do {
-        $swapped = false;
-        for ($i = 0, $c = sizeof($episodes) - 1; $i < $c; $i++) {
-            if (filemtime($_config['upload_dir'] . $episodes[$i]) < filemtime($_config['upload_dir'] . $episodes[$i + 1])) {
-                list($episodes[$i + 1], $episodes[$i]) = array($episodes[$i], $episodes[$i + 1]);
-                $swapped = true;
-            }
-        }
-    } while ($swapped);
-    // Get XML data for the certain episodes
+
+    // Sort entries according to their pubDates.
+    usort($episodes_mtimes, 'compare_mtimes');
+
+    // Get XML data for the episodes of interest.
     $episodes_data = array();
-    for ($i = 0; $i < sizeof($episodes); $i++) {
-        // We need to get the CDATA in plaintext
-        $xml = simplexml_load_file($_config['upload_dir'] . pathinfo('../' . $_config['upload_dir'] . $episodes[$i], PATHINFO_FILENAME) . '.xml', null, LIBXML_NOCDATA);
+    for ($i = 0; $i < sizeof($episodes_mtimes); $i++) {
+        $episode = $episodes_mtimes[$i][0];
+        // We need to get the CDATA in plaintext.
+        $xml_file_name = pathinfo('../' . $_config['upload_dir'] . $episode, PATHINFO_FILENAME) . '.xml';
+        $xml = simplexml_load_file($_config['upload_dir'] . $xml_file_name, null, LIBXML_NOCDATA);
         foreach ($xml as $item) {
-            // Skip episodes from the future
-            if (filemtime($_config['upload_dir'] . $episodes[$i]) > time()) {
-                break;
+            // If we are filtering by category, we can omit episodes
+            // that lack the desired category.
+            if ($category != null && $category != 'all') {
+                if ($item->categoriesPG->category1PG[0] != $category 
+                    && $item->categoriesPG->category2PG[0] != $category
+                    && $item->categoriesPG->category3PG[0] != $category) {
+                    continue;
+                }
             }
             $append_array = [
                 'episode' => [
@@ -70,25 +81,20 @@ function getEpisodes($category = null)
                         'bitrate' => $item->fileInfoPG->bitrate,
                         'frequency' => $item->fileInfoPG->frequency
                     ],
-                    'filename' => $episodes[$i],
-                    'moddate' => date('Y-m-d', filemtime($_config['upload_dir'] . $episodes[$i]))
+                    'filename' => $episode,
+                    'moddate' => date('Y-m-d', filemtime($_config['upload_dir'] . $episode))
                 ]
             ];
             array_push($episodes_data, $append_array);
         }
     }
     unset($_config);
-    if ($category == null || $category == 'all') {
-        return $episodes_data;
-    }
-    // Pop out non matching categories
-    $realepisodes = array();
-    foreach ($episodes_data as $item) {
-        $categories = array();
-        array_push($categories, $item['episode']['categoriesPG']['category1PG'][0], $item['episode']['categoriesPG']['category2PG'][0], $item['episode']['categoriesPG']['category3PG'][0]);
-        if (in_array($category, $categories)) {
-            array_push($realepisodes, $item);
-        }
-    }
-    return $realepisodes;
+    return $episodes_data;
+}
+
+// usort() compare function that reverse-sorts numeric values (which,
+// in our case, are file modification times.
+function compare_mtimes($a, $b)
+{
+    return $b[1] - $a[1];
 }


### PR DESCRIPTION
This improves getEpisodes() in a number of ways:

  - Rather than repeatedly querying file modification times (which is
    not a cheap operation), check each file's mtime once and remember
    it until we no longer need it.
  - Use the standard PHP usort() mechanism with a custom compare
    function that operates on cached modification times.
  - Rather than comparing file modification times against a constantly
    shifting time(), call time() once and compare against that static
    concept of "now".
  - Filter out entries omitted by category selection as early as
    possible, avoiding yet another array iteration and duplication
    loop.

In my dataset of 500+ episodes, these improvements result in a 4x
increase in performance (and corresponding decrease in page load
times).