### PR TITLE
Remove non-admin feed generation

### DIFF
--- a/PodcastGenerator/external.php
+++ b/PodcastGenerator/external.php
@@ -10,8 +10,6 @@
 require 'core/include.php';
 if (isset($_GET['name'])) {
     $buttons = getButtons('./');
-    // Regenerate feed on every access (just for the case)
-    generateRSS();
     foreach ($buttons as $item) {
         if ($_GET['name'] == $item->name) {
             if (!isset($item->protocol)) {

--- a/PodcastGenerator/index.php
+++ b/PodcastGenerator/index.php
@@ -20,7 +20,6 @@ if(isset($_GET['p'])) {
     }
 }
 
-generateRSS();
 $episodes = getEpisodes(null);
 
 // When calling name


### PR DESCRIPTION
Administrators should have full control of when their RSS feeds are
generated or refreshed, especially as this operation can be somewhat
filesystem-intensive (aggregating potentially thousands of XML
metadata files).  The feed.xml file is already updated after
administrative actions, can be updated via a private cron URL, and can
be updated explicitly and on-demand through the administrative
console.  That is sufficient.  There's simply no reason to allow every
anonymous page view to perform this function, not to allow other
read-only feed requests to do so.

In other words, PodcastGenerator *should* be able to run in static
mode on a read-only filesystem.